### PR TITLE
removed escape function from getBoundValue

### DIFF
--- a/src/Form/FormBuilder.php
+++ b/src/Form/FormBuilder.php
@@ -38,9 +38,9 @@ class FormBuilder extends _FormBuilder
                 ? $this->boundData->data()->translate($lang)->{$name}
                 : '';
 
-            return $this->escape($value);
+            return $value;
         }
 
-        return $this->escape($this->boundData->get($name, $default));
+        return $this->boundData->get($name, $default);
     }
 }


### PR DESCRIPTION
fixes Call to undefined method Propaganistas\LaravelTranslatableBootForms\Form\FormBuilder::escape() error after adamwathan/form release v.0.8.13